### PR TITLE
Update `shopify_app` Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "info": "shopify app info"
   },
   "dependencies": {
-    "@shopify/app": "3.22.1",
-    "@shopify/cli": "3.22.1"
+    "@shopify/app": "3.25.0",
+    "@shopify/cli": "3.25.0"
   },
   "author": "admin"
 }

--- a/web/Gemfile
+++ b/web/Gemfile
@@ -77,4 +77,4 @@ group :test do
 end
 
 gem "sidekiq"
-gem "shopify_app", "~> 21.2.0"
+gem "shopify_app", "~> 21.3.0"

--- a/web/app/controllers/authenticated_controller.rb
+++ b/web/app/controllers/authenticated_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AuthenticatedController < ApplicationController
-  include ShopifyApp::Authenticated
+  include ShopifyApp::EnsureHasSession
 end

--- a/web/app/controllers/home_controller.rb
+++ b/web/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@
 
 class HomeController < ApplicationController
   include ShopifyApp::EmbeddedApp
-  include ShopifyApp::RequireKnownShop
+  include ShopifyApp::EnsureInstalled
   include ShopifyApp::ShopAccessScopesVerification
 
   DEV_INDEX_PATH = Rails.root.join("frontend")

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -6,7 +6,7 @@ ShopifyApp.configure do |config|
     # to let your app know.
     { topic: "app/uninstalled", address: "api/webhooks/app_uninstalled" },
   ]
-  config.application_name = ENV.fetch("SHOPIFY_APP_NAME")
+  config.application_name = ENV.fetch("SHOPIFY_APP_NAME", "")
   config.old_secret = ""
   config.scope = ENV.fetch("SHOPIFY_API_SCOPES", "write_products") # See shopify.app.toml for scopes
   # Consult this page for more scope options: https://shopify.dev/api/usage/access-scopes
@@ -55,8 +55,8 @@ Rails.application.config.after_initialize do
       scope: ShopifyApp.configuration.scope,
       is_private: !ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", "").empty?,
       is_embedded: ShopifyApp.configuration.embedded_app,
-      session_storage: ShopifyApp::SessionRepository,
       logger: Rails.logger,
+      log_level: :info,
       private_shop: ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", nil),
       user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}",
     )


### PR DESCRIPTION
### WHY are these changes introduced?
A new `shopify_app` version is out.

### WHAT is this pull request doing?
- Updates deprecated versions
- Upgrade `shopify_app` version from `21.2.0` to `21.3.0`
- Upgrade `@shopify/app` from `3.22.1` to `3.25.0`
- Upgrade `@shopify/cli` from `3.22.1` to `3.25.0`

